### PR TITLE
modified resolution for OPi-PLUS

### DIFF
--- a/packages/mediacenter/kodi/config/guisettings.xml
+++ b/packages/mediacenter/kodi/config/guisettings.xml
@@ -1,4 +1,7 @@
 <settings>
+  <audiooutput>
+    <audiodevice>ALSA:sysdefault:CARD=sndhdmi</audiodevice>
+  </audiooutput>
   <debug>
     <screenshotpath pathversion="1">/storage/screenshots/</screenshotpath>
   </debug>

--- a/projects/H3/devices/OPiPlus/sys_config/orange_pi_plus.fex
+++ b/projects/H3/devices/OPiPlus/sys_config/orange_pi_plus.fex
@@ -472,13 +472,13 @@ disp_init_enable         = 1
 disp_mode                = 0
 
 screen0_output_type      = 3
-screen0_output_mode      = 4
+screen0_output_mode      = 10
 
 screen1_output_type      = 3
-screen1_output_mode      = 4
+screen1_output_mode      = 10
 
-;fb0_framebuffer_num      = 2
-fb0_format               = 0
+fb0_framebuffer_num      = 2
+fb0_format               = 10
 fb0_width                = 0
 fb0_height               = 0
 


### PR DESCRIPTION
currently resolution for the OPI-PLUS is limited to 720p50

changed in fex to 1080p60
